### PR TITLE
update dependencies slf4j, logback-classic, gson,  mysql-connector-ja…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,17 +90,17 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.25</version>
+        <version>1.7.29</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-nop</artifactId>
-        <version>1.7.25</version>
+        <version>1.7.29</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.1.3</version>
+        <version>1.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.jmock</groupId>
@@ -110,7 +110,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.8.1</version>
+        <version>2.8.6</version>
       </dependency>
       <dependency>
         <groupId>net.jpountz.lz4</groupId>
@@ -130,7 +130,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>8.0.17</version>
+        <version>8.0.18</version>
       </dependency>
       <dependency>
         <groupId>com.madgag.spongycastle</groupId>
@@ -145,17 +145,17 @@
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>5.13.2</version>
+        <version>5.13.4</version>
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-core</artifactId>
-        <version>1.21</version>
+        <version>1.22</version>
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-generator-annprocess</artifactId>
-        <version>1.21</version>
+        <version>1.22</version>
       </dependency>
       <dependency>
         <groupId>info.picocli</groupId>


### PR DESCRIPTION
…va, rocksdbjni, jmh.

slf4j from 1.7.25 to 1.7.29
logback-classic from 1.1.3 to 1.2.3
gson from 2.8.1 to 2.8.6
mysql-connector-java from 8.0.17 to 8.0.18
rocksdbjni from 5.13.2 to 5.13.4
jmh from 1.21 to 1.22